### PR TITLE
Updated api_key to apiKey as some clients translated underscored head…

### DIFF
--- a/src/auth/api-key.strategy.spec.ts
+++ b/src/auth/api-key.strategy.spec.ts
@@ -36,7 +36,7 @@ describe('ApiKeyStrategy', () => {
     it('should authenticate successfully when api_key is correct', () => {
       const req = mockRequest({
         headers: {
-          api_key: DEFAULT_API_KEY,
+          apiKey: DEFAULT_API_KEY,
         },
       });
       strategy.authenticate(req);
@@ -47,7 +47,7 @@ describe('ApiKeyStrategy', () => {
     it('should fail authentication when api_key is incorrect', () => {
       const req = mockRequest({
         headers: {
-          api_key: 'totally not valid',
+          apiKey: 'totally not valid',
         },
       });
       strategy.authenticate(req);
@@ -59,7 +59,7 @@ describe('ApiKeyStrategy', () => {
       expect(failArgs[1]).toBeNull();
     });
 
-    it('should fail authentication when api_key is missing', () => {
+    it('should fail authentication when apiKey is missing', () => {
       const req = mockRequest({
         headers: {},
       });

--- a/src/auth/api-key.strategy.ts
+++ b/src/auth/api-key.strategy.ts
@@ -15,7 +15,7 @@ export class ApiKeyStrategy extends PassportStrategy(
     @Inject(AppConfigService) private configService: AppConfigService,
   ) {
     super(
-      { header: 'api_key', prefix: '' },
+      { header: 'apiKey', prefix: '' },
       false,
       (apiKey: string, verified: VerifiedType) => {
         if (apiKey === configService.apiKey) {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -35,7 +35,7 @@ describe('AppController (e2e)', () => {
   it('/scan-file (POST) clean', () => {
     return request(app.getHttpServer())
       .post('/scan-file')
-      .set('api_key', '1234567')
+      .set('apiKey', '1234567')
       .attach('file', 'test/filesToScan/cleanFile.txt')
       .expect(200)
       .expect({ fileName: 'cleanFile.txt', infected: false, viruses: [] });


### PR DESCRIPTION
Updated api_key to apiKey as some clients translated underscore headers to hyphenated headers
e.g api_key becomes Api-Key which causes authentication issue